### PR TITLE
HIE-5 Make the Patient Interceptor configurable explicitly

### DIFF
--- a/api/src/main/java/org/openmrs/module/clientregistry/ClientRegistryConfig.java
+++ b/api/src/main/java/org/openmrs/module/clientregistry/ClientRegistryConfig.java
@@ -38,14 +38,22 @@ public class ClientRegistryConfig {
 	
 	@Value("${CLIENTREGISTRY_IDENTIFIERROOT:}")
 	private String identifierRoot;
+
+	@Value("${CLIENTREGISTRY_EVENTSENABLED:}")
+	private Boolean eventsEnabled;
 	
 	public boolean clientRegistryConnectionEnabled() {
 		return StringUtils.isNotBlank(getClientRegistryServerUrl());
+	}
+
+	public Boolean isClientRegistryEventsEnabled() {
+    	return Boolean.TRUE.equals(eventsEnabled) && clientRegistryConnectionEnabled();
 	}
 	
 	public String getClientRegistryServerUrl() {
 		return serverUrl;
 	}
+	
 	
 	public String getClientRegistryGetPatientEndpoint() {
 		String globalPropPatientEndpoint = administrationService

--- a/api/src/main/java/org/openmrs/module/clientregistry/ClientRegistryConstants.java
+++ b/api/src/main/java/org/openmrs/module/clientregistry/ClientRegistryConstants.java
@@ -17,6 +17,8 @@ public class ClientRegistryConstants {
 	public static final String GP_CLIENT_REGISTRY_PASSWORD = "CLIENTREGISTRY_PASSWORD";
 	
 	public static final String GP_CLIENT_REGISTRY_IDENTIFIER_ROOT = "CLIENTREGISTRY_IDENTIFIERROOT";
+
+	public static final String GP_CLIENT_REGISTRY_EVENTS_ENABLE = "CLIENTREGISTRY_EVENTSENABLE";
 	
 	public static final String GP_CLIENT_REGISTRY_TRANSACTION_METHOD = "clientregistry.transactionMethod";
 	


### PR DESCRIPTION
Linked Issue: https://openmrs.atlassian.net/browse/HIE-5

Added explicit configuration for Client Registry Events enablement:

Added new global property constant `GP_CLIENT_REGISTRY_EVENTS_ENABLE`
Introduced `eventsEnabled` configuration field
Events processing now requires both explicit enablement and valid server URL configuration
Improves configuration clarity and control over event-based functionality