### PR TITLE
ISSUE-21: Fix specifying count on queries via the global properties

### DIFF
--- a/api/src/main/java/org/openmrs/module/clientregistry/api/impl/FhirCRPatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/clientregistry/api/impl/FhirCRPatientServiceImpl.java
@@ -1,16 +1,16 @@
 package org.openmrs.module.clientregistry.api.impl;
 
-import ca.uhn.fhir.rest.api.server.IBundleProvider;
-import ca.uhn.fhir.rest.client.api.IGenericClient;
-import ca.uhn.fhir.rest.gclient.ICriterion;
-import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInputAndPartialOutput;
-import ca.uhn.fhir.rest.gclient.IQuery;
-import ca.uhn.fhir.rest.gclient.StringClientParam;
-import ca.uhn.fhir.rest.param.StringParam;
-import ca.uhn.fhir.rest.param.TokenParam;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
-import org.hl7.fhir.r4.model.*;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Reference;
 import org.openmrs.module.clientregistry.api.CRPatientService;
 import org.openmrs.module.clientregistry.api.search.CRSearchBundleProvider;
 import org.openmrs.module.clientregistry.api.search.PatientSearchCriteriaBuilder;
@@ -19,26 +19,31 @@ import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirGlobalPropertyService;
 import org.openmrs.module.fhir2.api.search.param.PatientSearchParams;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import org.springframework.beans.factory.annotation.Qualifier;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.gclient.ICriterion;
+import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInputAndPartialOutput;
+import ca.uhn.fhir.rest.gclient.IQuery;
+import ca.uhn.fhir.rest.gclient.StringClientParam;
+import ca.uhn.fhir.rest.param.StringParam;
+import ca.uhn.fhir.rest.param.TokenParam;
 
 @Component
 public class FhirCRPatientServiceImpl implements CRPatientService {
-	
+
 	@Autowired
 	@Qualifier("clientRegistryFhirClient")
 	private IGenericClient fhirClient;
-	
+
 	@Autowired
 	private PatientSearchCriteriaBuilder criteriaBuilder;
-	
+
 	@Autowired
 	private FhirGlobalPropertyService globalPropertyService;
-	
+
 	@Override
 	public Patient getPatientById(String id) {
 		if (StringUtils.isBlank(id)) {
@@ -46,41 +51,45 @@ public class FhirCRPatientServiceImpl implements CRPatientService {
 		}
 		return fhirClient.read().resource(Patient.class).withId(id).execute();
 	}
-	
+
 	@Override
 	public IBundleProvider getPatientsByPIX(String sourceIdentifier, String sourceIdentifierSystem,
-	        List<String> targetSystems) {
+			List<String> targetSystems) {
 		// construct request to external FHIR $ihe-pix endpoint
 		IOperationUntypedWithInputAndPartialOutput<Parameters> identifiersRequest = fhirClient.operation()
-		        .onType(FhirConstants.PATIENT).named(FhirCRConstants.IHE_PIX_OPERATION).withSearchParameter(Parameters.class,
-		            FhirCRConstants.SOURCE_IDENTIFIER, new TokenParam(sourceIdentifierSystem, sourceIdentifier));
-		
+				.onType(FhirConstants.PATIENT).named(FhirCRConstants.IHE_PIX_OPERATION)
+				.withSearchParameter(Parameters.class,
+						FhirCRConstants.SOURCE_IDENTIFIER, new TokenParam(sourceIdentifierSystem, sourceIdentifier));
+
 		if (!targetSystems.isEmpty()) {
 			identifiersRequest.andSearchParameter(FhirCRConstants.TARGET_SYSTEM,
-			    new StringParam(String.join(",", targetSystems)));
+					new StringParam(String.join(",", targetSystems)));
 		}
-		
+
 		Parameters crMatchingParams = identifiersRequest.useHttpGet().execute();
-		List<String> crIdentifiers = crMatchingParams.getParameter().stream().filter(param -> Objects.equals(param.getName(), "targetId"))
+		List<String> crIdentifiers = crMatchingParams.getParameter().stream()
+				.filter(param -> Objects.equals(param.getName(), "targetId"))
 				.map(param -> ((Reference) param.getValue()).getReference()).collect(Collectors.toList());
-		
+
 		if (crIdentifiers.isEmpty()) {
-			return new CRSearchBundleProvider(Collections.emptyList(), globalPropertyService);
+			return new CRSearchBundleProvider(Collections.emptyList());
 		}
-		
+
 		Bundle patientBundle = fhirClient.search().forResource(Patient.class)
-		        .where(new StringClientParam(Patient.SP_RES_ID).matches().values(crIdentifiers)).returnBundle(Bundle.class)
-		        .execute();
-		
-		return new CRSearchBundleProvider(parseCRPatientSearchResults(patientBundle), globalPropertyService);
-		
+				.where(new StringClientParam(Patient.SP_RES_ID).matches().values(crIdentifiers))
+				.count(globalPropertyService.getGlobalProperty(FhirConstants.OPENMRS_FHIR_DEFAULT_PAGE_SIZE, 10))
+				.returnBundle(Bundle.class)
+				.execute();
+
+		return new CRSearchBundleProvider(parseCRPatientSearchResults(patientBundle));
+
 	}
-	
+
 	@Override
 	public IBundleProvider searchPatients(PatientSearchParams patientSearchParams) {
 		List<ICriterion<?>> criterions = criteriaBuilder.buildCriteria(patientSearchParams);
 		IQuery<IBaseBundle> query = fhirClient.search().forResource(Patient.class);
-		
+
 		for (int i = 0; i < criterions.size(); i++) {
 			ICriterion<?> criterion = criterions.get(i);
 			if (i == 0) {
@@ -89,30 +98,33 @@ public class FhirCRPatientServiceImpl implements CRPatientService {
 				query.and(criterion);
 			}
 		}
+		query.count(globalPropertyService.getGlobalProperty(FhirConstants.OPENMRS_FHIR_DEFAULT_PAGE_SIZE, 10));
+
 		Bundle patientBundle = query.returnBundle(Bundle.class).execute();
-		return new CRSearchBundleProvider(parseCRPatientSearchResults(patientBundle), globalPropertyService);
+		return new CRSearchBundleProvider(parseCRPatientSearchResults(patientBundle));
 	}
-	
+
 	@Override
 	public Patient createPatient(Patient patient) {
 		return (Patient) fhirClient.create().resource(patient).execute().getResource();
 	}
-	
+
 	@Override
 	public Patient updatePatient(Patient patient) {
 		return (Patient) fhirClient.update().resource(patient).execute().getResource();
 	}
-	
+
 	@Override
 	public void purgePatient(Patient patient) {
 		fhirClient.delete().resource(patient).execute();
 	}
-	
+
 	/**
-	 * Filter and parse out fhir patients from Client Registry Patient Search results
+	 * Filter and parse out fhir patients from Client Registry Patient Search
+	 * results
 	 */
 	private List<Patient> parseCRPatientSearchResults(Bundle patientBundle) {
 		return patientBundle.getEntry().stream().filter(entry -> entry.getResource().hasType(FhirConstants.PATIENT))
-		        .map(entry -> (Patient) entry.getResource()).collect(Collectors.toList());
+				.map(entry -> (Patient) entry.getResource()).collect(Collectors.toList());
 	}
 }

--- a/api/src/main/java/org/openmrs/module/clientregistry/api/search/CRSearchBundleProvider.java
+++ b/api/src/main/java/org/openmrs/module/clientregistry/api/search/CRSearchBundleProvider.java
@@ -2,26 +2,15 @@ package org.openmrs.module.clientregistry.api.search;
 
 import java.io.Serializable;
 import java.util.List;
+
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.openmrs.module.fhir2.FhirConstants;
-import org.openmrs.module.fhir2.api.FhirGlobalPropertyService;
+
 import ca.uhn.fhir.rest.server.SimpleBundleProvider;
 
 public class CRSearchBundleProvider extends SimpleBundleProvider implements Serializable {
-	
-	private final FhirGlobalPropertyService globalPropertyService;
-	
-	public CRSearchBundleProvider(List<? extends IBaseResource> patientList, FhirGlobalPropertyService globalPropertyService) {
+
+	public CRSearchBundleProvider(List<? extends IBaseResource> patientList) {
 		super(patientList);
-		this.globalPropertyService = globalPropertyService;
 	}
-	
-	@Override
-	public Integer preferredPageSize() {
-		if (size() == null) {
-			setSize(globalPropertyService.getGlobalProperty(FhirConstants.OPENMRS_FHIR_DEFAULT_PAGE_SIZE, 10));
-		}
-		return size();
-	}
-	
+
 }


### PR DESCRIPTION
@samuelmale This PR has two major changes

1. I am removing the **preferredPageSize** method because it is redundant. The size is being set in the constructor. See the super class [here](https://hapifhir.io/hapi-fhir/apidocs/hapi-fhir-server/src-html/ca/uhn/fhir/rest/server/SimpleBundleProvider.html#line-72) and how it sets size with the size of the patient list.

2. I am setting the **count** param with the GP value seeing that different servers default to different values i.e 10. This is related to point 1 above that we never get chance to specify the count.

The rest of the changes are mainly formatting changes